### PR TITLE
fix: set Java 17 as version to use, prevent use of default Java 11

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,8 @@
+# Default version is Java 11
+#  - See https://cloud.google.com/docs/buildpacks/java#specify_a_java_version
+# Match the version required in pom.xml by setting it here
+#  - See https://cloud.google.com/docs/buildpacks/set-environment-variables#build_the_application_with_environment_variables
+
+[[build.env]]
+  name = "GOOGLE_RUNTIME_VERSION"
+  value = "17"


### PR DESCRIPTION
Fixes #88 

Default version is Java 11 ([source](https://cloud.google.com/docs/buildpacks/java#specify_a_java_version))

Match the version required in pom.xml setting the value in `pom.xml` ([source](https://cloud.google.com/docs/buildpacks/set-environment-variables#build_the_application_with_environment_variables))

Will allow Cloud Run source deploys and other buildpack-powered quickstarts to work without setting any flags or environment variables. 