### PR TITLE
fix: remove hardcoded runtime version for container build test

### DIFF
--- a/src/test/resources/advance.cloudbuild.yaml
+++ b/src/test/resources/advance.cloudbuild.yaml
@@ -26,7 +26,6 @@ steps:
       - build
       - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA" # Tag docker image with git commit SHA
       - "--builder=gcr.io/buildpacks/builder:v1"
-      - "--env=GOOGLE_RUNTIME_VERSION=17"
       - "--path=."
 
   - id: "Push Container Image"


### PR DESCRIPTION
#64 updated the version of Java for this test, but also included the runtime version in the test

#88 shows that without this flag (just using buildpacks by default), the build fails. 

Code changes in #89 will fix the default case (moving the config from a flag to a file that will then apply for all builds), but until #89 is merged, this PR will fail to build, proving the bug. 