### PR TITLE
feat: add manifest inspect output to nightly test

### DIFF
--- a/src/test/resources/advance.cloudbuild.yaml
+++ b/src/test/resources/advance.cloudbuild.yaml
@@ -27,6 +27,14 @@ steps:
       - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA" # Tag docker image with git commit SHA
       - "--builder=gcr.io/buildpacks/builder:v1"
       - "--path=."
+      
+  # Additional output for troubleshooting purposes
+  - id: "Output manifest inspect"
+    name: "gcr.io/cloud-builders/docker:latest"
+    args:
+      - manifest
+      - inspect 
+      - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
 
   - id: "Push Container Image"
     name: "gcr.io/cloud-builders/docker:latest"

--- a/src/test/resources/advance.cloudbuild.yaml
+++ b/src/test/resources/advance.cloudbuild.yaml
@@ -27,14 +27,15 @@ steps:
       - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA" # Tag docker image with git commit SHA
       - "--builder=gcr.io/buildpacks/builder:v1"
       - "--path=."
-      
+      - "-v"
+
   # Additional output for troubleshooting purposes
-  - id: "Output manifest inspect"
-    name: "gcr.io/cloud-builders/docker:latest"
+  - id: "Inspect Image"
+    name: "gcr.io/k8s-skaffold/pack"
+    entrypoint: pack
     args:
-      - manifest
-      - inspect 
-      - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
+      - inspect-image
+      - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA" 
 
   - id: "Push Container Image"
     name: "gcr.io/cloud-builders/docker:latest"


### PR DESCRIPTION
To out additional troubleshooting info, this PR adds the following to the java-nightly cloud build config file:
- the `-v` flag to the `pack build` step for more verbose output
- an additional step that will output the results of `pack inspect-image` 
Fixes #106 