### PR TITLE
fix: update import for metadata server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,12 @@ limitations under the License.
       <artifactId>spring-cloud-gcp-starter-logging</artifactId>
       <version>1.2.8.RELEASE</version>
     </dependency>
+
     <!-- Provides access the metadata server -->
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-core</artifactId>
-      <version>2.32.0</version>
+      <artifactId>spring-cloud-gcp-starter</artifactId>
+      <version>5.2.1</version>
     </dependency>
 
     <!-- Optionally include development tools -->


### PR DESCRIPTION
Resolves #150, #142 

## What happened

The dependency update in `com.google.cloud:google-cloud-core` shown in #142 caused import errors. Namely: 

```
java.lang.ClassNotFoundException: io.grpc.Context
```

## Why happened

Running unit tests locally (with `mvn test`) worked using 2.32.0, but not 2.33.0. 

Looking at what changed in 2.33.0, it's possible https://github.com/googleapis/sdk-platform-java/pull/ 2410 "chore: do not include optional dependencies in unmanaged dependency check" removed optional dependencies, which is why io.grpc.Context was no longer found. 

In the pom.xml, it says this package is used to "Provides access the metadata server"

Looking more into this package, it looks like this is a parent package of we actually need. https://github.com/googleapis/sdk-platform-java/tree/main/java-core says "Note: This library is only meant to be consumed by other Google Libraries.". 

## How fix

Looking more into what other code samples have `ServiceOptions.getDefaultProjectId`, and what packages they use to get this function, I've chosen one that looks like something that's common in this context. It may not be the minimum package, but testing locally it works (pending CI). 

